### PR TITLE
Fixed typo for calling Yeast GO library

### DIFF
--- a/R/GOenrichmentAnalysis.R
+++ b/R/GOenrichmentAnalysis.R
@@ -92,7 +92,7 @@ GOenrichmentAnalysis = function(labels, entrezCodes,
         entrezCodes = yeastORFs
       } else {
         # Map the entrez IDs to yeast ORFs
-        x = eval(parse(text = "org.Sc.sgd:::org.Sc.sgdENTREZID"))
+        x = eval(parse(text = "org.Sc.sgd.db:::org.Sc.sgdENTREZID"))
         # x = org.Sc.sgd:::org.Sc.sgdENTREZID
         xx = as.list(x[mapped_genes])
         allORFs = names(xx);


### PR DESCRIPTION
The GO.db package for yeast on Bioconductor is called org.Sc.sgd.db, so references and calls to this library should be "org.Sc.sgd.db" instead of "org.Sc.sgd". 

Case in point, I am able to load "org.Sc.sgd.db:::org.Sc.sgdENTREZID" but not "org.Sc.sgd:::org.Sc.sgdENTREZID" as it is currently listed. 