### PR TITLE
Ensure p-values are numeric before sorting

### DIFF
--- a/R/qvalue.R
+++ b/R/qvalue.R
@@ -87,6 +87,7 @@ qvalue <- function(p, lambda=seq(0,0.90,0.05), pi0.method="smoother", fdr.level=
     if(!is.null(fdr.level) && (fdr.level<=0 || fdr.level>1))  ## change by Alan:  check for valid fdr.level
         stop("qvalue:: 'fdr.level' must be within (0, 1].")
 #The estimated q-values calculated here
+    p <- as.numeric(p)
     u <- order(p)
 
     # change by Alan


### PR DESCRIPTION
The p variable may at some point become a list of character strings that when sorted, do not sort properly due to the number of digits in the p-value. For instance, a p-value of 0.999984 would be sorted as being larger than 0.9999864 even though it's numeric value is smaller. 

I believe this has the effect of increasing the q-values from the qvalue function because the list is no longer in order, so larger q-values may sometimes be treated as being smaller. This will then decrease the number of significant associations output by WGCNA.

Therefore, either ensure that the p-values are numeric before sorting or cast it to a numeric type.